### PR TITLE
transfer from Edgeware repo to Agile Content

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 #Include EFP
 include(ExternalProject)
 ExternalProject_Add(project_efp
-        GIT_REPOSITORY https://github.com/Unit-X/efp.git
+        GIT_REPOSITORY https://github.com/agilecontent/efp.git
         GIT_SUBMODULES ""
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/efp
         BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/efp

--- a/LISENCE.md
+++ b/LISENCE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2020 Edgeware AB
+Copyright (c) 2020 Edgeware AB, 2021-2022 Agile Content
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # EFPSignal
 
-The EFPSignal is a control plane used by [ElasticFrameProtocol](https://github.com/Unit-X/efp).
+The EFPSignal is a control plane used by [ElasticFrameProtocol](https://github.com/agilecontent/efp).
 
 ```
 --------------------------------------------------------- ---     /\
@@ -169,7 +169,7 @@ Add this in your CMake file.
 #Include EFPSignal
 include(ExternalProject)
 ExternalProject_Add(project_efpsignal
-        GIT_REPOSITORY https://github.com/Unit-X/efpsignal.git
+        GIT_REPOSITORY https://github.com/agilecontent/efpsignal.git
         GIT_SUBMODULES ""
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/efpsignal
         BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/efpsignal
@@ -214,15 +214,12 @@ Add header file to your project.
 
 ## History
 
-The data content framed using ElasticFrameProtocol is promiscuously added and transported. The receiver is also given what is sent without any declaration of the content. EFPSignal is helping out declaring content and filtering streams of data if configured that way. When using MPEG-TS PAT and PMT has been used to declare content extended by using private data. The older declaration and signaling of media was designed in a simplex world. EFPSignal on the other hand is designed for duplex IP networks for OOB and IB signaling using JSON or binary data types. This enables more flexible ways of working with media flows (pub/sub). For example, a receiver can subscribe to content after receiving the declaration and deciding on what content to subscribe to. It’s also possible to dynamically subscribe and delete content for creating flows adapting to the capacity of the network or the capabilities of the consumer.  
+The data content framed using ElasticFrameProtocol is promiscuously added and transported. The receiver is also given what is sent without any declaration of the content. EFPSignal is helping out declaring content and filtering streams of data if configured that way. When using MPEG-TS PAT and PMT has been used to declare content extended by using private data. The older declaration and signaling of media was designed in a simplex world. EFPSignal on the other hand is designed for duplex IP networks for OOB and IB signaling using JSON or binary data types. This enables more flexible ways of working with media flows (pub/sub). For example, a receiver can subscribe to content after receiving the declaration and deciding on what content to subscribe to. It’s also possible to dynamically subscribe and delete content for creating flows adapting to the capacity of the network or the capabilities of the consumer.
 
 
 ## Credits
 
-The UnitX team at Edgeware AB
-
-Maintainer: anders.cedronius(at)edgeware.tv
-
+The UnitX team at Edgeware AB, from 2021 part of Agile Content
 
 ## License
 

--- a/duplex.cpp
+++ b/duplex.cpp
@@ -1,3 +1,4 @@
+// Copyright Edgeware AB 2020, Agile Content 2021-2022
 #include <iostream>
 #include "efpsignal.h"
 

--- a/efpsignal.cpp
+++ b/efpsignal.cpp
@@ -1,7 +1,4 @@
-//
-// UnitX Edgeware AB 2020
-//
-
+// Copyright Edgeware AB 2020, Agile Content 2021-2022
 #include "efpsignal.h"
 #include "logger.h"
 

--- a/efpsignal.h
+++ b/efpsignal.h
@@ -1,8 +1,4 @@
-// EFPSignal
-//
-// UnitX Edgeware AB 2020
-//
-
+// Copyright Edgeware AB 2020, Agile Content 2021-2022
 #ifndef EFPSIGNAL__EFPSIGNAL_H
 #define EFPSIGNAL__EFPSIGNAL_H
 
@@ -275,11 +271,6 @@ private:
  * EFPSignalSend is subclassing ElasticFrameProtocolSender and overloads 'the pack and send' methods
  * EFPSignalSend registers and filters the elementary data based on user settings
  *
- * \author UnitX
- *
- * Contact: bitbucket:andersced
- * or-> anders dot cedronius at edgeware dot tv
- *
  */
 class EFPSignalSend : public ElasticFrameProtocolSender {
 public:
@@ -519,9 +510,6 @@ private:
  *
  * ElasticFrameProtocolSender can be used to frame elementary streams to EFP fragments for transport over any network technology
  *
- * \author UnitX
- *
- * Contact: bitbucket:andersced
  *
  */
 class EFPSignalReceive : public ElasticFrameProtocolReceiver {

--- a/logger.h
+++ b/logger.h
@@ -1,7 +1,4 @@
-//
-// UnitX Edgeware AB 2020
-//
-
+// Copyright Edgeware AB 2020, Agile Content 2021-2022
 #ifndef LOGGER_H
 #define LOGGER_H
 

--- a/simplex.cpp
+++ b/simplex.cpp
@@ -1,3 +1,4 @@
+// Copyright Edgeware AB 2020, Agile Content 2021-2022
 #include <iostream>
 #include "efpsignal.h"
 


### PR DESCRIPTION
Change repo owner from unit-x to agilecontent GitHub repo.
This is part of a major transfer of all EFP code to Agile Content.